### PR TITLE
Added database collation to default configuration

### DIFF
--- a/config-default.json
+++ b/config-default.json
@@ -7,6 +7,7 @@
         "host": "localhost",
         "port": null,
         "charset": "utf8mb4",
+        "collation": "utf8mb4_unicode_ci",
         "dbname": "ext-{@nameHyphen}",
         "user": "root",
         "password": ""


### PR DESCRIPTION
As part of the development process, I have needed to drop and create the database using build.js from the extension-tools repository. The collation value is required. There will be an accompanying pull request for the other repository.