### PR TITLE
Added logger level to default configuration

### DIFF
--- a/config-default.json
+++ b/config-default.json
@@ -18,5 +18,8 @@
         "siteUrl": "http://localhost/ext-{@nameHyphen}/site",
         "adminUsername": "admin",
         "adminPassword": "1"
+    },
+    "logger": {
+        "level": "DEBUG"
     }
 }


### PR DESCRIPTION
The development process relies heavily upon debug statements. I know the setting can be added to config.php, which is perfectly fine as well, but I thought it might save everyone time if it was in the default configuration because it is very useful for development of an extension.