### PR TITLE
fix broken clear-cache command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "composer-install": "node build --composer-install",
     "sync": "node build --copy && node build --composer-install",
     "extension": "node build --extension",
-    "clear-cache": "php site/clear_cache.php",
+    "clear-cache": "cd site && php clear_cache.php",
     "rebuild": "node build --rebuild",
     "all": "node build --all",
     "prepare-test": "node build --prepare-test"


### PR DESCRIPTION
It fixes error when running `npm run clear-cache`

```bash
PHP Warning:  require(vendor/autoload.php): Failed to open stream: No such file or directory in /var/www/some-extension/bootstrap.php on line 5
PHP Fatal error:  Uncaught Error: Failed opening required 'vendor/autoload.php' (include_path='.:/usr/share/php') in /var/www/some-extension/bootstrap.php:5
Stack trace:
#0 /var/www/some-extension/site/clear_cache.php(30): include()
#1 {main}
  thrown in /var/www/some-extension/bootstrap.php on line 5
```